### PR TITLE
[배포] Nginx 컨테이너 볼륨 경로 변경

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     volumes:
       - ./nginx/sites-enabled:/etc/nginx/conf.d
       - django_static:/static
-      - /home/ubuntu/anam-earth/frontend/build:/build
+      - /home/ubuntu/anam-earth/frontend:/frontend
     depends_on:
       - backend
 

--- a/deploy/nginx/sites-enabled/frontend.conf
+++ b/deploy/nginx/sites-enabled/frontend.conf
@@ -4,7 +4,7 @@ server {
 
     location / {
         root /build;
-        index index.html index.htm;
+        index index.html;
         try_files $uri /index.html;
     }
 }


### PR DESCRIPTION
프론트엔드 배포 시 build 디렉토리 없어지는 문제 해결 위해 build 대신 상위 디렉토리에 bind mount